### PR TITLE
Для работы css, js и других файлов требуется корректное значение Content-Type

### DIFF
--- a/Serv-Practice/server.rb
+++ b/Serv-Practice/server.rb
@@ -32,13 +32,13 @@ while (session = server.accept)
       else
         '404'
       end
-  STATUS =
+  status =
       if File.file?(file_path)
         '200'
       else
         '404'
       end
-  response = "HTTP/1.1 #{STATUS}\r\n"
+  response = "HTTP/1.1 #{status}\r\n"
   response << "Content-Type: #{content_type(file_path)}\r\n"
   response << "\r\n"
   response << body

--- a/Serv-Practice/server.rb
+++ b/Serv-Practice/server.rb
@@ -2,7 +2,21 @@ require 'socket'
 
 server = TCPServer.new(9999)
 
-SERVER_ROOT = "/home/user1/myRep/Web-Practice/HTML-Practice"
+SERVER_ROOT = "C:\\Users\\tablo\\RubymineProjects\\Web-Practice\\HTML-Practice"
+
+def content_type(full_path)
+  _name, extension = full_path.split('.')
+  case extension
+  when 'html'
+    'text/html'
+  when 'css'
+    'text/css'
+  when 'js'
+    'text/javascript'
+  else
+    'application/octet-stream'
+  end
+end
 
 while (session = server.accept)
   request = session.gets
@@ -25,7 +39,7 @@ while (session = server.accept)
         '404'
       end
   response = "HTTP/1.1 #{STATUS}\r\n"
-  response << "Content-Type: text/html\r\n"
+  response << "Content-Type: #{content_type(file_path)}\r\n"
   response << "\r\n"
   response << body
   session.print response


### PR DESCRIPTION
Кроме того поправил `Warning`и и добавил пример путей в Windows. `\` является спецсимволом, поэтому его нужно экранировать, альтернативным способом будет запись строк в друой форме (одинарные кавычки):
`SERVER_ROOT = 'C:\Users\tablo\RubymineProjects\Web-Practice\HTML-Practice'`